### PR TITLE
Show version defined in metadata of package

### DIFF
--- a/elitech/src/main.py
+++ b/elitech/src/main.py
@@ -17,12 +17,13 @@
 
 import argparse
 from .commands import Command
+import importlib.metadata
 
 def main():
     parser = argparse.ArgumentParser(description="Console tool to interact with Elitech temperature and humidity loggers")
     parser.add_argument('-d', '--dev', '--device', action='store', default='',
                         help='The device to interact with')
-    parser.add_argument('-v', '--version', action='version', version='%(prog)s 0.0')
+    parser.add_argument('-v', '--version', action='version', version='%(prog)s ' + importlib.metadata.version('elitech'))
     parser.add_argument('cmds', action='extend', nargs='+',
                         help="The commands to execute. To see help on a specific command, use the 'help' command.")
     args = parser.parse_args()


### PR DESCRIPTION
After introducing the Python package, it makes sense to get the version defined in the package metadata. This is shown with the -v parameter.